### PR TITLE
Fix doc and typos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "justcsv"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "derive_more",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "justcsv"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Alexander Kalashnikov"]
 description = "Simple CSV-file reader/writer"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,8 +142,5 @@ mod tests {
             b"1,2,3\r\n4,\"5\"\"abc\"\"X\",\"6\n\tagain\"",
             buf.as_slice()
         );
-        println!("CSV: {}", String::from_utf8(buf).unwrap());
     }
 }
-// println!("Line 1: {:?}", reader.next());
-// println!("Line 2: {:?}", reader.next());

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -9,13 +9,17 @@ pub use config::Config as CsvReaderConfig;
 /// # Example
 ///
 /// ```
-/// let input = std::fs::File::open(path)?;
-/// let buf = std::io::BufReader::new(input);
-/// let reader = CsvReader::new(buf);
-/// for (line, record) in reader.enumerate() {
-///     let record = record?;
-///     println!("{:4}. {:?}", line, record);
-/// }
+/// let buf = "\"1\",2,3\r\n4, \"everybody needs\nmilk\",6".as_bytes();
+/// let mut reader = justcsv::CsvReader::new(buf);
+/// assert_eq!(
+///     vec!["1", "2", "3"],
+///     reader.next().unwrap().unwrap().into_vec()
+/// );
+/// assert_eq!(
+///     vec!["4", "everybody needs\nmilk", "6"],
+///     reader.next().unwrap().unwrap().into_vec()
+/// );
+/// assert!(reader.next().is_none());
 /// ```
 pub struct CsvReader<R> {
     source: R,
@@ -99,7 +103,7 @@ fn load_headers<R: BufRead>(source: R, comma: char, dquote: char) -> Option<Box<
 
 mod config {
 
-    /// Data structure with CSV reader options
+    /// Data struct with CSV reader options
     pub struct Config {
         /// User expects CSV headers
         pub has_headers: bool,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -5,19 +5,18 @@ use std::io::Write;
 /// CSV writer to save UTF-8 content as comma separated values.
 /// Basically CSV document is a slice of records which are basically `&str` slices.
 ///
-/// # Examples
+/// # Example
 ///
 /// ```
-/// for x in 0..u16::MAX {
-///     writer.write_row(&[format!("{x}"), format!("{log}", log = (x as f64).ln())])?;
-/// }
-/// ```
-///
-/// ```
-/// let data = (0..u16::MAX)
-///     .map(|x| vec![format!("{x}"), format!("{log}", log = (x as f64).log2())])
-///     .collect::<Vec<_>>();
-/// writer.write_document(data.as_slice())?;
+/// let mut buf = Vec::new();
+/// let row = vec!["1", "2", "3"];
+/// let mut writer = justcsv::CsvWriter::new(&mut buf);
+/// writer.write_row(&row).unwrap();
+/// writer.write_row(["4", "5\"abc\"X", "6\n\tagain"]).unwrap();
+/// assert_eq!(
+///     b"1,2,3\r\n4,\"5\"\"abc\"\"X\",\"6\n\tagain\"",
+///     buf.as_slice()
+/// );
 /// ```
 pub struct CsvWriter<W> {
     dest: W,


### PR DESCRIPTION
- Change the doctest examples to be passed.
- Some typo fix.
- Remove unnecessary comments and printlns.